### PR TITLE
Fixed bug in horace.m to enable fitmode to work.

### DIFF
--- a/mfiles/@sw/horace.m
+++ b/mfiles/@sw/horace.m
@@ -158,7 +158,7 @@ for tt = 1:nTwin
 end
 
 % normalised volume fractions of the twins
-vol = spectra.obj.twin.vol/sum(spectra.obj.twin.vol);
+vol = obj.twin.vol/sum(obj.twin.vol);
 for tt = 1:nTwin
     for ii = 1:size(DSF,1)
         DSF{ii,tt}    = DSF{ii,tt}*vol(tt);


### PR DESCRIPTION
Line 161 refers to spectra.obj, but the obj field is not created by sw/spinwave if fitmode is used. Changed it to refer to the master obj rather that in spectra.